### PR TITLE
Update docker-publish.yml

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -78,6 +78,7 @@ jobs:
         with:
           context: .
           file: .env/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ${{ env.GITHUB_REGISTRY }}/${{ env.IMAGE_LOWERCASE_OWNER }}/${{ env.IMAGE_LOWERCASE_NAME }}:${{ env.IMAGE_TAG }}


### PR DESCRIPTION
Add multi-arch image to workflow. This makes it possible to directly run the project in docker on both modern ARM64 and AMD64 machines.