### PR TITLE
fix(method): Floco fixes and better default parameters

### DIFF
--- a/src/client/floco.py
+++ b/src/client/floco.py
@@ -16,9 +16,7 @@ class FlocoClient(FedAvgClient):
 
     def set_parameters(self, package: dict[str, Any]):
         super().set_parameters(package)
-        if package["subregion_parameters"]:
-            self.model.sample_from = package["sample_from"]
-            self.model.subregion_parameters = package["subregion_parameters"]
+        self.model.subregion_parameters = package["subregion_parameters"]
         if self.args.floco.pers_epoch > 0:  # Floco+
             self.global_params = OrderedDict(
                 (key, param.to(self.device))
@@ -59,9 +57,9 @@ class FlocoClient(FedAvgClient):
     @torch.no_grad()
     def evaluate(self):
         if self.args.floco.pers_epoch > 0:  # Floco+
-            super().evaluate(self.pers_model)
+            return super().evaluate(self.pers_model)
         else:
-            super().evaluate()
+            return super().evaluate()
 
 
 def training_loop(
@@ -93,6 +91,6 @@ def training_loop(
 
 
 def _regularize_pers_model(model, reg_model_params, lamda):
-    for pers_param, global_param in zip(model.parameters(), reg_model_params):
+    for pers_param, global_param in zip(model.parameters(), reg_model_params.values()):
         if pers_param.requires_grad and pers_param.grad is not None:
             pers_param.grad.data += lamda * pers_param.data - global_param.data


### PR DESCRIPTION
Bugfix and better default parameters (10 simplex endpoints and client projection after 10 rounds) for Floco ([Federated Learning over Connected Modes](https://openreview.net/forum?id=JL2eMCfDW8), #138).



Tested on cifar10 (`python generate_data.py -d cifar10 -a 0.1 -cn 100`).

Local test accuracies (reproduce with `dataset.name=cifar10 common.test.client.interval=1`):
- FedAvg (`python main.py method=fedavg`): 53.84%
- Floco (`python main.py method=floco`): 77.15%
- Floco+ (`python main.py method=floco` +floco.pers_epoch=1): 78.95%

Again thanks for the nice framework, you're doing an amazing job