### PR TITLE
Periodic updates

### DIFF
--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -19,8 +19,8 @@ model:
   use_torchvision_pretrained_weights: true
 
   # The model parameters `.pt` file relative path to the directory of FL-bench.
-  # This feature is enabled only when `unique_model=False`,
-  # which is pre-defined and fixed by each FL method.
+  # This feature is enabled only when `all_model_params_personalized=False`,
+  # which is defined and fixed by each FL method.
   external_model_weights_path: null
 
 # The learning rate scheduler that used for client local training.
@@ -71,7 +71,7 @@ parallel:
 
   # Should be set larger than 1, or training mode fallback to `serial`
   # Set a larger `num_workers` can further boost efficiency,
-  # but also let each worker have less computational resources.
+  # but also increases the computational overhead.
   num_workers: 2
 
 common:
@@ -101,7 +101,7 @@ common:
 
   # The evaluation settings for client side and server side.
   test:
-    # For example, Set client.testset as true to evaluate on local testsets from selected clients with client local models.
+    # For example, Set client.test as true to evaluate on local testsets from selected clients with client local models.
     # Frequency is set by `client.interval`. Negative value for disabling.
     client:
       interval: 100
@@ -109,9 +109,10 @@ common:
       train: false
       val: false
       test: true
-    # For example, set server.trainset as true to evaluate on a centralized testset (created by aggregating all clients' local testsets)
+    # For example, set server.test as true to evaluate on a centralized testset (created by aggregating all clients' local testsets)
     # with the updated global model at the end of a communication round.
     # Frequency is set by `server.interval`. Negative value for disabling.
+    # NOTE: If clients have personalized model parameters like local buffers or classifiers, centralized evaluation for the global model is disabled.
     server:
       interval: -1
       train: false
@@ -138,7 +139,7 @@ common:
 # FL-bench uses FL method arguments by args.<method>.<arg>.
 # You need to follow the key set in `get_hyperparams()` in class <method>Server, src/server/<method>.py
 # FL-bench will ignore these arguments if they are not supported by the selected method,
-# e.g., if you are running FedProx, then pfedsim arguments will be ignored.
+# e.g., if you are running FedProx, then pFedSim arguments will be ignored.
 fedprox:
   mu: 0.01
 pfedsim:

--- a/src/server/apfl.py
+++ b/src/server/apfl.py
@@ -9,6 +9,11 @@ from src.server.fedavg import FedAvgServer
 
 
 class APFLServer(FedAvgServer):
+    algorithm_name: str = "APFL"
+    all_model_params_personalized = False  # `True` indicates that clients have their own fullset of personalized model parameters.
+    return_diff = False  # `True` indicates that clients return `diff = W_global - W_local` as parameter update; `False` for `W_local` only.
+    client_cls = APFLClient
+
     @staticmethod
     def get_hyperparams(args_list=None) -> Namespace:
         parser = ArgumentParser()
@@ -16,18 +21,8 @@ class APFLServer(FedAvgServer):
         parser.add_argument("--adaptive_alpha", type=int, default=1)
         return parser.parse_args(args_list)
 
-    def __init__(
-        self,
-        args: DictConfig,
-        algorithm_name: str = "APFL",
-        unique_model=False,
-        use_fedavg_client_cls=False,
-        return_diff=False,
-    ):
-        super().__init__(
-            args, algorithm_name, unique_model, use_fedavg_client_cls, return_diff
-        )
-        self.init_trainer(APFLClient)
+    def __init__(self, args: DictConfig):
+        super().__init__(args)
         self.client_local_model_params = {
             i: deepcopy(self.model.state_dict()) for i in self.train_clients
         }

--- a/src/server/ccvr.py
+++ b/src/server/ccvr.py
@@ -1,10 +1,8 @@
 from argparse import ArgumentParser, Namespace
-from collections import OrderedDict
 from copy import deepcopy
 
 import numpy as np
 import torch
-from omegaconf import DictConfig
 from torch.utils.data import DataLoader, Dataset
 
 from src.client.ccvr import CCVRClient
@@ -13,24 +11,16 @@ from src.utils.constants import NUM_CLASSES
 
 
 class CCVRServer(FedAvgServer):
+    algorithm_name: str = "CCVR"
+    all_model_params_personalized = False  # `True` indicates that clients have their own fullset of personalized model parameters.
+    return_diff = False  # `True` indicates that clients return `diff = W_global - W_local` as parameter update; `False` for `W_local` only.
+    client_cls = CCVRClient
+
     @staticmethod
     def get_hyperparams(args_list=None) -> Namespace:
         parser = ArgumentParser()
         parser.add_argument("--sample_per_class", type=int, default=200)
         return parser.parse_args(args_list)
-
-    def __init__(
-        self,
-        args: DictConfig,
-        algorithm_name: str = "CCVR",
-        unique_model=False,
-        use_fedavg_client_cls=False,
-        return_diff=False,
-    ):
-        super().__init__(
-            args, algorithm_name, unique_model, use_fedavg_client_cls, return_diff
-        )
-        self.init_trainer(CCVRClient)
 
     def test_client_models(self):
         frz_global_params_dict = deepcopy(self.public_model_params)

--- a/src/server/cfl.py
+++ b/src/server/cfl.py
@@ -10,6 +10,10 @@ from src.utils.functional import vectorize
 
 
 class CFLServer(FedAvgServer):
+    algorithm_name: str = "CFL"
+    all_model_params_personalized = True  # `True` indicates that clients have their own fullset of personalized model parameters.
+    return_diff = True  # `True` indicates that clients return `diff = W_global - W_local` as parameter update; `False` for `W_local` only.
+
     @staticmethod
     def get_hyperparams(args_list=None) -> Namespace:
         parser = ArgumentParser()
@@ -19,17 +23,8 @@ class CFLServer(FedAvgServer):
         parser.add_argument("--start_clustering_round", type=int, default=20)
         return parser.parse_args(args_list)
 
-    def __init__(
-        self,
-        args: DictConfig,
-        algorithm_name: str = "CFL",
-        unique_model=True,
-        use_fedavg_client_cls=True,
-        return_diff=True,
-    ):
-        super().__init__(
-            args, algorithm_name, unique_model, use_fedavg_client_cls, return_diff
-        )
+    def __init__(self, args: DictConfig):
+        super().__init__(args)
         assert (
             len(self.train_clients) == self.client_num
         ), "CFL doesn't support `User` type split."

--- a/src/server/ditto.py
+++ b/src/server/ditto.py
@@ -8,6 +8,11 @@ from src.server.fedavg import FedAvgServer
 
 
 class DittoServer(FedAvgServer):
+    algorithm_name: str = "Ditto"
+    all_model_params_personalized = False  # `True` indicates that clients have their own fullset of personalized model parameters.
+    return_diff = False  # `True` indicates that clients return `diff = W_global - W_local` as parameter update; `False` for `W_local` only.
+    client_cls = DittoClient
+
     @staticmethod
     def get_hyperparams(args_list=None) -> Namespace:
         parser = ArgumentParser()
@@ -15,18 +20,8 @@ class DittoServer(FedAvgServer):
         parser.add_argument("--lamda", type=float, default=1)
         return parser.parse_args(args_list)
 
-    def __init__(
-        self,
-        args: DictConfig,
-        algorithm_name: str = "Ditto",
-        unique_model=False,
-        use_fedavg_client_cls=False,
-        return_diff=False,
-    ):
-        super().__init__(
-            args, algorithm_name, unique_model, use_fedavg_client_cls, return_diff
-        )
-        self.init_trainer(DittoClient)
+    def __init__(self, args: DictConfig):
+        super().__init__(args)
         self.clients_personalized_model_params = {
             i: deepcopy(self.model.state_dict()) for i in self.train_clients
         }

--- a/src/server/elastic.py
+++ b/src/server/elastic.py
@@ -3,14 +3,17 @@ from collections import OrderedDict
 from typing import Any
 
 import torch
-from omegaconf import DictConfig
-from torch._tensor import Tensor
 
 from src.client.elastic import ElasticClient
 from src.server.fedavg import FedAvgServer
 
 
 class ElasticServer(FedAvgServer):
+    algorithm_name: str = "Elastic"
+    all_model_params_personalized = False  # `True` indicates that clients have their own fullset of personalized model parameters.
+    return_diff = True  # `True` indicates that clients return `diff = W_global - W_local` as parameter update; `False` for `W_local` only.
+    client_cls = ElasticClient
+
     @staticmethod
     def get_hyperparams(args_list=None) -> Namespace:
         parser = ArgumentParser()
@@ -18,19 +21,6 @@ class ElasticServer(FedAvgServer):
         parser.add_argument("--tau", type=float, default=0.5)
         parser.add_argument("--mu", type=float, default=0.95)
         return parser.parse_args(args_list)
-
-    def __init__(
-        self,
-        args: DictConfig,
-        algorithm_name: str = "Elastic",
-        unique_model=False,
-        use_fedavg_client_cls=False,
-        return_diff=True,
-    ):
-        super().__init__(
-            args, algorithm_name, unique_model, use_fedavg_client_cls, return_diff
-        )
-        self.init_trainer(ElasticClient)
 
     def aggregate_client_updates(
         self, client_packages: OrderedDict[int, dict[str, Any]]

--- a/src/server/fedala.py
+++ b/src/server/fedala.py
@@ -1,12 +1,15 @@
 from argparse import ArgumentParser, Namespace
 
-from omegaconf import DictConfig
-
 from src.client.fedala import FedALAClient
 from src.server.fedavg import FedAvgServer
 
 
 class FedALAServer(FedAvgServer):
+    algorithm_name = "FedALA"
+    all_model_params_personalized = False  # `True` indicates that clients have their own fullset of personalized model parameters.
+    return_diff = False  # `True` indicates that clients return `diff = W_global - W_local` as parameter update; `False` for `W_local` only.
+    client_cls = FedALAClient
+
     @staticmethod
     def get_hyperparams(args_list=None) -> Namespace:
         parser = ArgumentParser()
@@ -38,16 +41,3 @@ class FedALAServer(FedAvgServer):
             help="The percent of the local training data to sample.",
         )
         return parser.parse_args(args_list)
-
-    def __init__(
-        self,
-        args: DictConfig,
-        algorithm_name: str = "FedALA",
-        unique_model=False,
-        use_fedavg_client_cls=False,
-        return_diff=False,
-    ):
-        super().__init__(
-            args, algorithm_name, unique_model, use_fedavg_client_cls, return_diff
-        )
-        self.init_trainer(FedALAClient)

--- a/src/server/fedap.py
+++ b/src/server/fedap.py
@@ -14,6 +14,11 @@ from src.server.fedavg import FedAvgServer
 
 # Codes below are modified from FedAP's official repo: https://github.com/microsoft/PersonalizedFL
 class FedAPServer(FedAvgServer):
+    algorithm_name = "FedAP"
+    all_model_params_personalized = False  # `True` indicates that clients have their own fullset of personalized model parameters.
+    return_diff = False  # `True` indicates that clients return `diff = W_global - W_local` as parameter update; `False` for `W_local` only.
+    client_cls = FedAPClient
+
     @staticmethod
     def get_hyperparams(args_list=None) -> Namespace:
         parser = ArgumentParser()
@@ -25,21 +30,11 @@ class FedAPServer(FedAvgServer):
         parser.add_argument("--model_momentum", type=float, default=0.5)
         return parser.parse_args(args_list)
 
-    def __init__(
-        self,
-        args: DictConfig,
-        algorithm_name: str = None,
-        unique_model=False,
-        use_fedavg_client_cls=False,
-        return_diff=False,
-    ):
+    def __init__(self, args: DictConfig):
         algo_name = {"original": "FedAP", "f": "f-FedAP", "d": "d-FedAP"}
-        algo = algo_name[args.fedap.version]
-        super().__init__(
-            args, algorithm_name, unique_model, use_fedavg_client_cls, return_diff
-        )
+        self.algorithm_name = algo_name[args.fedap.version]
+        super().__init__(args)
 
-        self.init_trainer(FedAPClient)
         self.weight_matrix = torch.eye(self.client_num)
         self.pretrain_round = 0
         if 0 < self.args.fedap.warmup_round < 1:

--- a/src/server/fedas.py
+++ b/src/server/fedas.py
@@ -8,6 +8,11 @@ from src.server.fedavg import FedAvgServer
 
 
 class FedASServer(FedAvgServer):
+    algorithm_name = "FedAS"
+    all_model_params_personalized = False  # `True` indicates that clients have their own fullset of personalized model parameters.
+    return_diff = False  # `True` indicates that clients return `diff = W_global - W_local` as parameter update; `False` for `W_local` only.
+    client_cls = FedASClient
+
     @staticmethod
     def get_hyperparams(args_list=None) -> Namespace:
         parser = ArgumentParser()
@@ -15,19 +20,9 @@ class FedASServer(FedAvgServer):
         parser.add_argument("--alignment_epoch", type=int, default=1)
         return parser.parse_args(args_list)
 
-    def __init__(
-        self,
-        args: DictConfig,
-        algorithm_name: str = "FedAS",
-        unique_model=False,
-        use_fedavg_client_cls=False,
-        return_diff=False,
-    ):
-        super().__init__(
-            args, algorithm_name, unique_model, use_fedavg_client_cls, return_diff
-        )
+    def __init__(self, args: DictConfig):
+        super().__init__(args)
         self.client_prev_model_states: Dict[int, Dict[str, Any]] = {}
-        self.init_trainer(FedASClient)
 
     def train_one_round(self):
         """The function of indicating specific things FL method need to do (at

--- a/src/server/fedavgm.py
+++ b/src/server/fedavgm.py
@@ -8,23 +8,19 @@ from src.server.fedavg import FedAvgServer
 
 
 class FedAvgMServer(FedAvgServer):
+    algorithm_name: str = "FedAvgM"
+    all_model_params_personalized = False  # `True` indicates that clients have their own fullset of personalized model parameters.
+    return_diff = True  # `True` indicates that clients return `diff = W_global - W_local` as parameter update; `False` for `W_local` only.
+
     @staticmethod
     def get_hyperparams(args_list=None) -> Namespace:
         parser = ArgumentParser()
         parser.add_argument("--server_momentum", type=float, default=0.9)
         return parser.parse_args(args_list)
 
-    def __init__(
-        self,
-        args: DictConfig,
-        algorithm_name: str = "FedAvgM",
-        unique_model=False,
-        use_fedavg_client_cls=True,
-        return_diff=True,
-    ):
-        super().__init__(
-            args, algorithm_name, unique_model, use_fedavg_client_cls, return_diff
-        )
+    def __init__(self, args: DictConfig):
+        super().__init__(args)
+
         self.global_optmizer = torch.optim.SGD(
             list(self.public_model_params.values()),
             lr=1.0,

--- a/src/server/fedbabu.py
+++ b/src/server/fedbabu.py
@@ -5,19 +5,14 @@ from src.server.fedavg import FedAvgServer
 
 
 class FedBabuServer(FedAvgServer):
-    def __init__(
-        self,
-        args: DictConfig,
-        algorithm_name: str = "FedBabu",
-        unique_model=False,
-        use_fedavg_client_cls=False,
-        return_diff=False,
-    ):
+    algorithm_name = "FedBabu"
+    all_model_params_personalized = False  # `True` indicates that clients have their own fullset of personalized model parameters.
+    return_diff = False  # `True` indicates that clients return `diff = W_global - W_local` as parameter update; `False` for `W_local` only.
+    client_cls = FedBabuClient
+
+    def __init__(self, args: DictConfig):
         # Fine-tuning is indispensable to FedBabu.
         assert (
             args.common.test.client.finetune_epoch > 0
         ), f"FedBABU needs finetuning. Now finetune_epoch = {args.common.test.client.finetune_epoch}"
-        super().__init__(
-            args, algorithm_name, unique_model, use_fedavg_client_cls, return_diff
-        )
-        self.init_trainer(FedBabuClient)
+        super().__init__(args)

--- a/src/server/fedbn.py
+++ b/src/server/fedbn.py
@@ -7,17 +7,13 @@ from src.server.fedavg import FedAvgServer
 
 
 class FedBNServer(FedAvgServer):
-    def __init__(
-        self,
-        args: DictConfig,
-        algorithm_name: str = "FedBN",
-        unique_model=False,
-        use_fedavg_client_cls=False,
-        return_diff=False,
-    ):
-        super().__init__(
-            args, algorithm_name, unique_model, use_fedavg_client_cls, return_diff
-        )
+    algorithm_name = "FedBN"
+    all_model_params_personalized = False  # `True` indicates that clients have their own fullset of personalized model parameters.
+    return_diff = False  # `True` indicates that clients return `diff = W_global - W_local` as parameter update; `False` for `W_local` only.
+    client_cls = FedBNClient
+
+    def __init__(self, args: DictConfig):
+        super().__init__(args)
         init_bn_params = dict(
             (key, param)
             for key, param in self.model.state_dict().items()
@@ -25,4 +21,3 @@ class FedBNServer(FedAvgServer):
         )
         for params_dict in self.clients_personal_model_params.values():
             params_dict.update(deepcopy(init_bn_params))
-        self.init_trainer(FedBNClient)

--- a/src/server/feddyn.py
+++ b/src/server/feddyn.py
@@ -1,6 +1,5 @@
 from argparse import ArgumentParser, Namespace
 from collections import OrderedDict
-from copy import deepcopy
 from typing import Any
 
 import torch
@@ -13,6 +12,11 @@ from src.utils.functional import vectorize
 
 # Fixed according to FedDyn implementation in FL-Simulator (issue #133)
 class FedDynServer(FedAvgServer):
+    algorithm_name = "FedDyn"
+    all_model_params_personalized = "False"
+    return_diff = True  # `True` indicates that clients return `diff = W_global - W_local` as parameter update; `False` for `W_local` only.
+    client_cls = FedDynClient
+
     @staticmethod
     def get_hyperparams(args_list=None) -> Namespace:
         parser = ArgumentParser()
@@ -20,18 +24,8 @@ class FedDynServer(FedAvgServer):
         parser.add_argument("--max_grad_norm", type=float, default=10)
         return parser.parse_args(args_list)
 
-    def __init__(
-        self,
-        args: DictConfig,
-        algorithm_name: str = "FedDyn",
-        unique_model=False,
-        use_fedavg_client_cls=False,
-        return_diff=True,
-    ):
-        super().__init__(
-            args, algorithm_name, unique_model, use_fedavg_client_cls, return_diff
-        )
-        self.init_trainer(FedDynClient)
+    def __init__(self, args: DictConfig):
+        super().__init__(args)
         param_numel = vectorize(self.public_model_params).numel()
         self.nabla = torch.zeros(size=(self.client_num, param_numel))
 

--- a/src/server/fedem.py
+++ b/src/server/fedem.py
@@ -1,7 +1,4 @@
 from argparse import ArgumentParser, Namespace
-from collections import OrderedDict
-from copy import deepcopy
-from typing import Any, Dict
 
 import torch
 from omegaconf import DictConfig
@@ -12,27 +9,23 @@ from src.utils.models import MODELS
 
 
 class FedEMServer(FedAvgServer):
+    algorithm_name: str = "FedEM"
+    all_model_params_personalized = False  # `True` indicates that clients have their own fullset of personalized model parameters.
+    return_diff = False  # `True` indicates that clients return `diff = W_global - W_local` as parameter update; `False` for `W_local` only.
+    client_cls = FedEMClient
+
     @staticmethod
     def get_hyperparams(args_list=None) -> Namespace:
         parser = ArgumentParser()
         parser.add_argument("--n_learners", type=int, default=3)
         return parser.parse_args(args_list)
 
-    def __init__(
-        self,
-        args: DictConfig,
-        algorithm_name: str = "FedEM",
-        unique_model=False,
-        use_fedavg_client_cls=False,
-        return_diff=False,
-    ):
-        if args.common.test.server.interval <= args.common.global_epoch:
+    def __init__(self, args: DictConfig):
+        if 0 < args.common.test.server.interval <= args.common.global_epoch:
             raise NotImplementedError(
                 "FedEM is not supported for global model testing on server side."
             )
-        super().__init__(
-            args, algorithm_name, unique_model, use_fedavg_client_cls, return_diff
-        )
+        super().__init__(args, False, False)
         self.init_model(
             model=EnsembleModel(
                 learners=[
@@ -50,7 +43,7 @@ class FedEMServer(FedAvgServer):
         self.model.check_and_preprocess(self.args)
         self.client_data_sample_weights = {i: None for i in range(self.client_num)}
         self.client_learner_weights = {i: None for i in range(self.client_num)}
-        self.init_trainer(FedEMClient)
+        self.init_trainer()
 
     def package(self, client_id):
         server_package = super().package(client_id)

--- a/src/server/fedfomo.py
+++ b/src/server/fedfomo.py
@@ -8,6 +8,11 @@ from src.server.fedavg import FedAvgServer
 
 
 class FedFomoServer(FedAvgServer):
+    algorithm_name: str = "FedFomo"
+    all_model_params_personalized = True  # `True` indicates that clients have their own fullset of personalized model parameters.
+    return_diff = False  # `True` indicates that clients return `diff = W_global - W_local` as parameter update; `False` for `W_local` only.
+    client_cls = FedFomoClient
+
     @staticmethod
     def get_hyperparams(args_list=None) -> Namespace:
         parser = ArgumentParser()
@@ -15,18 +20,8 @@ class FedFomoServer(FedAvgServer):
         parser.add_argument("--valset_ratio", type=float, default=0.2)
         return parser.parse_args(args_list)
 
-    def __init__(
-        self,
-        args: DictConfig,
-        algorithm_name: str = "FedFomo",
-        unique_model=True,
-        use_fedavg_client_cls=False,
-        return_diff=False,
-    ):
-        super().__init__(
-            args, algorithm_name, unique_model, use_fedavg_client_cls, return_diff
-        )
-        self.init_trainer(FedFomoClient)
+    def __init__(self, args: DictConfig):
+        super().__init__(args)
         self.P = torch.eye(self.client_num, device=self.device)
 
     def train_one_round(self):

--- a/src/server/fediir.py
+++ b/src/server/fediir.py
@@ -8,6 +8,11 @@ from src.server.fedavg import FedAvgServer
 
 
 class FedIIRServer(FedAvgServer):
+    algorithm_name: str = "FedIIR"
+    all_model_params_personalized = False  # `True` indicates that clients have their own fullset of personalized model parameters.
+    return_diff = False  # `True` indicates that clients return `diff = W_global - W_local` as parameter update; `False` for `W_local` only.
+    client_cls = FedIIRClient
+
     @staticmethod
     def get_hyperparams(args_list=None) -> Namespace:
         parser = ArgumentParser()
@@ -15,22 +20,12 @@ class FedIIRServer(FedAvgServer):
         parser.add_argument("--penalty", type=float, default=1e-3)
         return parser.parse_args(args_list)
 
-    def __init__(
-        self,
-        args: DictConfig,
-        algorithm_name: str = "FedIIR",
-        unique_model=False,
-        use_fedavg_client_cls=False,
-        return_diff=False,
-    ):
-        super().__init__(
-            args, algorithm_name, unique_model, use_fedavg_client_cls, return_diff
-        )
+    def __init__(self, args: DictConfig):
+        super().__init__(args)
         self.grad_mean = tuple(
             torch.zeros_like(p) for p in list(self.model.classifier.parameters())
         )
         self.calculating_grad_mean = False
-        self.init_trainer(FedIIRClient)
 
     def package(self, client_id: int):
         server_package = super().package(client_id)

--- a/src/server/fedlc.py
+++ b/src/server/fedlc.py
@@ -1,7 +1,5 @@
 from argparse import ArgumentParser, Namespace
 
-from omegaconf import DictConfig
-
 from src.client.fedlc import FedLCClient
 from src.server.fedavg import FedAvgServer
 
@@ -16,21 +14,13 @@ More discussions about FedLC: https://github.com/KarhouTam/FL-bench/issues/5
 
 
 class FedLCServer(FedAvgServer):
+    algorithm_name: str = "FedLC"
+    all_model_params_personalized = False  # `True` indicates that clients have their own fullset of personalized model parameters.
+    return_diff = False  # `True` indicates that clients return `diff = W_global - W_local` as parameter update; `False` for `W_local` only.
+    client_cls = FedLCClient
+
     @staticmethod
     def get_hyperparams(args_list=None) -> Namespace:
         parser = ArgumentParser()
         parser.add_argument("--tau", type=float, default=1.0)
         return parser.parse_args(args_list)
-
-    def __init__(
-        self,
-        args: DictConfig,
-        algorithm_name: str = "FedLC",
-        unique_model=False,
-        use_fedavg_client_cls=False,
-        return_diff=False,
-    ):
-        super().__init__(
-            args, algorithm_name, unique_model, use_fedavg_client_cls, return_diff
-        )
-        self.init_trainer(FedLCClient)

--- a/src/server/fedopt.py
+++ b/src/server/fedopt.py
@@ -9,6 +9,10 @@ from src.server.fedavg import FedAvgServer
 
 
 class FedOptServer(FedAvgServer):
+    algorithm_name: str = "FedOpt"
+    all_model_params_personalized = False  # `True` indicates that clients have their own fullset of personalized model parameters.
+    return_diff = True  # `True` indicates that clients return `diff = W_global - W_local` as parameter update; `False` for `W_local` only.
+
     @staticmethod
     def get_hyperparams(args_list=None) -> Namespace:
         parser = ArgumentParser()
@@ -21,20 +25,13 @@ class FedOptServer(FedAvgServer):
         parser.add_argument("--tau", type=float, default=1e-3)
         return parser.parse_args(args_list)
 
-    algo_names = {"adagrad": "FedAdagrad", "yogi": "FedYogi", "adam": "FedAdam"}
-
-    def __init__(
-        self,
-        args: DictConfig,
-        algorithm_name: str = "FedAvg",
-        unique_model=False,
-        use_fedavg_client_cls=True,
-        return_diff=True,
-    ):
-        algo = self.algo_names[args.fedopt.type]
-        super().__init__(
-            args, algorithm_name, unique_model, use_fedavg_client_cls, return_diff
-        )
+    def __init__(self, args: DictConfig):
+        self.algorithm_name = {
+            "adagrad": "FedAdagrad",
+            "yogi": "FedYogi",
+            "adam": "FedAdam",
+        }[args.fedopt.type]
+        super().__init__(args)
         self.adaptive_optimizer = AdaptiveOptimizer(
             optimizer_type=self.args.fedopt.type,
             params_dict=self.public_model_params,

--- a/src/server/fedpac.py
+++ b/src/server/fedpac.py
@@ -12,6 +12,11 @@ from src.utils.constants import NUM_CLASSES
 
 
 class FedPACServer(FedAvgServer):
+    algorithm_name: str = "FedPAC"
+    all_model_params_personalized = False  # `True` indicates that clients have their own fullset of personalized model parameters.
+    return_diff = False  # `True` indicates that clients return `diff = W_global - W_local` as parameter update; `False` for `W_local` only.
+    client_cls = FedPACClient
+
     @staticmethod
     def get_hyperparams(args_list=None):
         parser = ArgumentParser()
@@ -20,19 +25,9 @@ class FedPACServer(FedAvgServer):
         parser.add_argument("--classifier_lr", type=float, default=0.1)
         return parser.parse_args(args_list)
 
-    def __init__(
-        self,
-        args: DictConfig,
-        algorithm_name: str = "FedPAC",
-        unique_model=False,
-        use_fedavg_client_cls=False,
-        return_diff=False,
-    ):
-        super().__init__(
-            args, algorithm_name, unique_model, use_fedavg_client_cls, return_diff
-        )
+    def __init__(self, args: DictConfig):
+        super().__init__(args)
         self.global_prototypes = {}
-        self.init_trainer(FedPACClient)
 
     def package(self, client_id: int):
         server_package = super().package(client_id)

--- a/src/server/fedper.py
+++ b/src/server/fedper.py
@@ -1,19 +1,9 @@
-from omegaconf import DictConfig
-
 from src.client.fedper import FedPerClient
 from src.server.fedavg import FedAvgServer
 
 
 class FedPerServer(FedAvgServer):
-    def __init__(
-        self,
-        args: DictConfig,
-        algorithm_name: str = "FedPer",
-        unique_model=False,
-        use_fedavg_client_cls=False,
-        return_diff=False,
-    ):
-        super().__init__(
-            args, algorithm_name, unique_model, use_fedavg_client_cls, return_diff
-        )
-        self.init_trainer(FedPerClient)
+    algorithm_name: str = "FedPer"
+    all_model_params_personalized = False  # `True` indicates that clients have their own fullset of personalized model parameters.
+    return_diff = False  # `True` indicates that clients return `diff = W_global - W_local` as parameter update; `False` for `W_local` only.
+    client_cls = FedPerClient

--- a/src/server/fedproto.py
+++ b/src/server/fedproto.py
@@ -9,25 +9,20 @@ from src.utils.constants import NUM_CLASSES
 
 
 class FedProtoServer(FedAvgServer):
+    algorithm_name: str = "FedProto"
+    all_model_params_personalized = False  # `True` indicates that clients have their own fullset of personalized model parameters.
+    return_diff = False  # `True` indicates that clients return `diff = W_global - W_local` as parameter update; `False` for `W_local` only.
+    client_cls = FedProtoClient
+
     @staticmethod
     def get_hyperparams(args_list=None) -> Namespace:
         parser = ArgumentParser()
         parser.add_argument("--lamda", type=float, default=1)
         return parser.parse_args(args_list)
 
-    def __init__(
-        self,
-        args: DictConfig,
-        algorithm_name: str = "FedProto",
-        unique_model=False,
-        use_fedavg_client_cls=False,
-        return_diff=False,
-    ):
-        super().__init__(
-            args, algorithm_name, unique_model, use_fedavg_client_cls, return_diff
-        )
+    def __init__(self, args: DictConfig):
+        super().__init__(args)
         self.global_prototypes: dict[int, torch.Tensor] = {}
-        self.init_trainer(FedProtoClient)
 
     def package(self, client_id: int):
         server_package = super().package(client_id)

--- a/src/server/fedprox.py
+++ b/src/server/fedprox.py
@@ -1,27 +1,17 @@
 from argparse import ArgumentParser, Namespace
 
-from omegaconf import DictConfig
-
 from src.client.fedprox import FedProxClient
 from src.server.fedavg import FedAvgServer
 
 
 class FedProxServer(FedAvgServer):
+    algorithm_name: str = "FedProx"
+    all_model_params_personalized = False  # `True` indicates that clients have their own fullset of personalized model parameters.
+    return_diff = False  # `True` indicates that clients return `diff = W_global - W_local` as parameter update; `False` for `W_local` only.
+    client_cls = FedProxClient
+
     @staticmethod
     def get_hyperparams(args_list=None) -> Namespace:
         parser = ArgumentParser()
         parser.add_argument("--mu", type=float, default=1.0)
         return parser.parse_args(args_list)
-
-    def __init__(
-        self,
-        args: DictConfig,
-        algorithm_name: str = "FedProx",
-        unique_model=False,
-        use_fedavg_client_cls=False,
-        return_diff=False,
-    ):
-        super().__init__(
-            args, algorithm_name, unique_model, use_fedavg_client_cls, return_diff
-        )
-        self.init_trainer(FedProxClient)

--- a/src/server/fedrep.py
+++ b/src/server/fedrep.py
@@ -1,27 +1,17 @@
 from argparse import ArgumentParser, Namespace
 
-from omegaconf import DictConfig
-
 from src.client.fedrep import FedRepClient
 from src.server.fedavg import FedAvgServer
 
 
 class FedRepServer(FedAvgServer):
+    algorithm_name: str = "FedRep"
+    all_model_params_personalized = False  # `True` indicates that clients have their own fullset of personalized model parameters.
+    return_diff = False  # `True` indicates that clients return `diff = W_global - W_local` as parameter update; `False` for `W_local` only.
+    client_cls = FedRepClient
+
     @staticmethod
     def get_hyperparams(args_list=None) -> Namespace:
         parser = ArgumentParser()
         parser.add_argument("--train_body_epoch", type=int, default=1)
         return parser.parse_args(args_list)
-
-    def __init__(
-        self,
-        args: DictConfig,
-        algorithm_name: str = "FedRep",
-        unique_model=False,
-        use_fedavg_client_cls=False,
-        return_diff=False,
-    ):
-        super().__init__(
-            args, algorithm_name, unique_model, use_fedavg_client_cls, return_diff
-        )
-        self.init_trainer(FedRepClient)

--- a/src/server/fedrod.py
+++ b/src/server/fedrod.py
@@ -12,6 +12,11 @@ from src.utils.constants import NUM_CLASSES
 
 
 class FedRoDServer(FedAvgServer):
+    algorithm_name: str = "FedRoD"
+    all_model_params_personalized = False  # `True` indicates that clients have their own fullset of personalized model parameters.
+    return_diff = False  # `True` indicates that clients return `diff = W_global - W_local` as parameter update; `False` for `W_local` only.
+    client_cls = FedRoDClient
+
     @staticmethod
     def get_hyperparams(args_list=None) -> Namespace:
         parser = ArgumentParser()
@@ -22,17 +27,8 @@ class FedRoDServer(FedAvgServer):
         parser.add_argument("--eval_per", type=int, default=1)
         return parser.parse_args(args_list)
 
-    def __init__(
-        self,
-        args: DictConfig,
-        algorithm_name: str = "FedRoD",
-        unique_model=False,
-        use_fedavg_client_cls=False,
-        return_diff=False,
-    ):
-        super().__init__(
-            args, algorithm_name, unique_model, use_fedavg_client_cls, return_diff
-        )
+    def __init__(self, args: DictConfig):
+        super().__init__(args, False)
         self.hyper_params_dict = None
         self.hypernetwork: nn.Module = None
         if self.args.fedrod.hyper:
@@ -48,7 +44,7 @@ class FedRoDServer(FedAvgServer):
             for key, param in self.hypernetwork.named_parameters():
                 self.hyper_params_dict[key] = param.data.clone()
         self.first_time_selected = [True for _ in self.train_clients]
-        self.init_trainer(FedRoDClient, hypernetwork=self.hypernetwork)
+        self.init_trainer(hypernetwork=self.hypernetwork)
 
     def package(self, client_id: int):
         server_package = super().package(client_id)

--- a/src/server/floco.py
+++ b/src/server/floco.py
@@ -14,6 +14,11 @@ from src.utils.models import MODELS, DecoupledModel
 
 
 class FlocoServer(FedAvgServer):
+    algorithm_name: str = "Floco"
+    all_model_params_personalized = False  # `True` indicates that clients have their own fullset of personalized model parameters.
+    return_diff = False  # `True` indicates that clients return `diff = W_global - W_local` as parameter update; `False` for `W_local` only.
+    client_cls = FlocoClient
+
     @staticmethod
     def get_hyperparams(args_list=None) -> Namespace:
         parser = ArgumentParser()
@@ -27,31 +32,14 @@ class FlocoServer(FedAvgServer):
 
         return parser.parse_args(args_list)
 
-    def __init__(
-        self,
-        args: DictConfig,
-        algorithm_name: str = "Floco",
-        unique_model=False,
-        use_fedavg_client_cls=True,
-        return_diff=False,
-    ):
-        super().__init__(
-            args, algorithm_name, unique_model, use_fedavg_client_cls, return_diff
-        )
-        self.model = SimplexModel(self.args)
-        self.model.check_and_preprocess(self.args)
-        _init_global_params, _init_global_params_name = [], []
-        for key, param in self.model.named_parameters():
-            _init_global_params.append(param.data.clone())
-            _init_global_params_name.append(key)
-        self.public_model_param_names = _init_global_params_name
-        self.public_model_params: OrderedDict[str, torch.Tensor] = OrderedDict(
-            zip(_init_global_params_name, _init_global_params)
-        )
-        self.init_trainer(FlocoClient)
+    def __init__(self, args: DictConfig):
+        super().__init__(args, False, False)
+        self.init_model(SimplexModel(self.args))
+        self.init_trainer()
         self.projected_clients = None
 
         if self.args.floco.pers_epoch > 0:  # Floco+
+            self.all_model_params_personalized = True
             self.clients_personalized_model_params = {
                 i: deepcopy(self.model.state_dict()) for i in self.train_clients
             }

--- a/src/server/flute.py
+++ b/src/server/flute.py
@@ -3,7 +3,6 @@ from argparse import ArgumentParser, Namespace
 from typing import Any
 
 import torch
-from omegaconf import DictConfig
 
 from src.client.flute import FLUTEClient
 from src.server.fedavg import FedAvgServer
@@ -11,6 +10,11 @@ from src.utils.constants import NUM_CLASSES
 
 
 class FLUTEServer(FedAvgServer):
+    algorithm_name: str = "FLUTE"
+    all_model_params_personalized = False  # `True` indicates that clients have their own fullset of personalized model parameters.
+    return_diff = False  # `True` indicates that clients return `diff = W_global - W_local` as parameter update; `False` for `W_local` only.
+    client_cls = FLUTEClient
+
     @staticmethod
     def get_hyperparams(args_list=None) -> Namespace:
         parser = ArgumentParser()
@@ -22,19 +26,6 @@ class FLUTEServer(FedAvgServer):
         parser.add_argument("--gamma2", type=float, default=1)
         parser.add_argument("--nc2_lr", type=float, default=0.5)
         return parser.parse_args(args_list)
-
-    def __init__(
-        self,
-        args: DictConfig,
-        algorithm_name: str = "FLUTE",
-        unique_model=False,
-        use_fedavg_client_cls=False,
-        return_diff=False,
-    ):
-        super().__init__(
-            args, algorithm_name, unique_model, use_fedavg_client_cls, return_diff
-        )
-        self.init_trainer(FLUTEClient)
 
     def train_one_round(self):
         clients_package = self.trainer.train()

--- a/src/server/knnper.py
+++ b/src/server/knnper.py
@@ -1,12 +1,15 @@
 from argparse import ArgumentParser, Namespace
 
-from omegaconf import DictConfig
-
 from src.client.knnper import kNNPerClient
 from src.server.fedavg import FedAvgServer
 
 
 class kNNPerServer(FedAvgServer):
+    algorithm_name: str = "kNN-Per"
+    all_model_params_personalized = False  # `True` indicates that clients have their own fullset of personalized model parameters.
+    return_diff = False  # `True` indicates that clients return `diff = W_global - W_local` as parameter update; `False` for `W_local` only.
+    client_cls = kNNPerClient
+
     @staticmethod
     def get_hyperparams(args_list=None) -> Namespace:
         parser = ArgumentParser()
@@ -15,16 +18,3 @@ class kNNPerServer(FedAvgServer):
         parser.add_argument("--scale", type=float, default=1)
         parser.add_argument("--k", type=int, default=5)
         return parser.parse_args(args_list)
-
-    def __init__(
-        self,
-        args: DictConfig,
-        algorithm_name: str = "kNN-Per",
-        unique_model=False,
-        use_fedavg_client_cls=False,
-        return_diff=False,
-    ):
-        super().__init__(
-            args, algorithm_name, unique_model, use_fedavg_client_cls, return_diff
-        )
-        self.init_trainer(kNNPerClient)

--- a/src/server/lgfedavg.py
+++ b/src/server/lgfedavg.py
@@ -1,27 +1,17 @@
 from argparse import ArgumentParser, Namespace
 
-from omegaconf import DictConfig
-
 from src.client.lgfedavg import LGFedAvgClient
 from src.server.fedavg import FedAvgServer
 
 
 class LGFedAvgServer(FedAvgServer):
+    algorithm_name: str = "LG-FedAvg"
+    all_model_params_personalized = False  # `True` indicates that clients have their own fullset of personalized model parameters.
+    return_diff = False  # `True` indicates that clients return `diff = W_global - W_local` as parameter update; `False` for `W_local` only.
+    client_cls = LGFedAvgClient
+
     @staticmethod
     def get_hyperparams(args_list=None) -> Namespace:
         parser = ArgumentParser()
         parser.add_argument("--num_global_layers", type=int, default=1)
         return parser.parse_args(args_list)
-
-    def __init__(
-        self,
-        args: DictConfig,
-        algorithm_name: str = "LG-FedAvg",
-        unique_model=False,
-        use_fedavg_client_cls=False,
-        return_diff=False,
-    ):
-        super().__init__(
-            args, algorithm_name, unique_model, use_fedavg_client_cls, return_diff
-        )
-        self.init_trainer(LGFedAvgClient)

--- a/src/server/local.py
+++ b/src/server/local.py
@@ -1,20 +1,10 @@
-from omegaconf import DictConfig
-
 from src.server.fedavg import FedAvgServer
 
 
 class LocalServer(FedAvgServer):
-    def __init__(
-        self,
-        args: DictConfig,
-        algorithm_name: str = "Local-only",
-        unique_model=True,
-        use_fedavg_client_cls=True,
-        return_diff=False,
-    ):
-        super().__init__(
-            args, algorithm_name, unique_model, use_fedavg_client_cls, return_diff
-        )
+    algorithm_name: str = "Local-only"
+    all_model_params_personalized = True  # `True` indicates that clients have their own fullset of personalized model parameters.
+    return_diff = False  # `True` indicates that clients return `diff = W_global - W_local` as parameter update; `False` for `W_local` only.
 
     def train_one_round(self):
         client_packages = self.trainer.train()

--- a/src/server/moon.py
+++ b/src/server/moon.py
@@ -7,6 +7,11 @@ from src.server.fedavg import FedAvgServer
 
 
 class MOONServer(FedAvgServer):
+    algorithm_name: str = "MOON"
+    all_model_params_personalized = False  # `True` indicates that clients have their own fullset of personalized model parameters.
+    return_diff = False  # `True` indicates that clients return `diff = W_global - W_local` as parameter update; `False` for `W_local` only.
+    client_cls = MOONClient
+
     @staticmethod
     def get_hyperparams(args_list=None) -> Namespace:
         parser = ArgumentParser()
@@ -14,18 +19,8 @@ class MOONServer(FedAvgServer):
         parser.add_argument("--mu", type=float, default=5)
         return parser.parse_args(args_list)
 
-    def __init__(
-        self,
-        args: DictConfig,
-        algorithm_name: str = "MOON",
-        unique_model=False,
-        use_fedavg_client_cls=False,
-        return_diff=False,
-    ):
-        super().__init__(
-            args, algorithm_name, unique_model, use_fedavg_client_cls, return_diff
-        )
-        self.init_trainer(MOONClient)
+    def __init__(self, args: DictConfig):
+        super().__init__(args)
         self.clients_prev_model_params = {i: {} for i in self.train_clients}
 
     def package(self, client_id: int):

--- a/src/server/perfedavg.py
+++ b/src/server/perfedavg.py
@@ -7,6 +7,11 @@ from src.server.fedavg import FedAvgServer
 
 
 class PerFedAvgServer(FedAvgServer):
+    algorithm_name: str = "Per-FedAvg"
+    all_model_params_personalized = False  # `True` indicates that clients have their own fullset of personalized model parameters.
+    return_diff = False  # `True` indicates that clients return `diff = W_global - W_local` as parameter update; `False` for `W_local` only.
+    client_cls = PerFedAvgClient
+
     @staticmethod
     def get_hyperparams(args_list=None) -> Namespace:
         parser = ArgumentParser()
@@ -15,19 +20,9 @@ class PerFedAvgServer(FedAvgServer):
         parser.add_argument("--delta", type=float, default=1e-3)
         return parser.parse_args(args_list)
 
-    def __init__(
-        self,
-        args: DictConfig,
-        algorithm_name: str = "Per-FedAvg(FO)",
-        unique_model=False,
-        use_fedavg_client_cls=False,
-        return_diff=False,
-    ):
-        algo = "Per-FedAvg(FO)" if args.perfedavg.version == "fo" else "Per-FedAvg(HF)"
+    def __init__(self, args: DictConfig):
+        self.algorithm_name += "(FO)" if args.perfedavg.version == "fo" else "(HF)"
         args.common.test.client.finetune_epoch = max(
             1, args.common.test.client.finetune_epoch
         )
-        super().__init__(
-            args, algorithm_name, unique_model, use_fedavg_client_cls, return_diff
-        )
-        self.init_trainer(PerFedAvgClient)
+        super().__init__(args)

--- a/src/server/pfedfda.py
+++ b/src/server/pfedfda.py
@@ -10,6 +10,11 @@ from src.utils.constants import NUM_CLASSES
 
 
 class pFedFDAServer(FedAvgServer):
+    algorithm_name: str = "pFedFDA"
+    all_model_params_personalized = False  # `True` indicates that clients have their own fullset of personalized model parameters.
+    return_diff = False  # `True` indicates that clients return `diff = W_global - W_local` as parameter update; `False` for `W_local` only.
+    client_cls = pFedFDAClient
+
     @staticmethod
     def get_hyperparams(arg_list: Optional[List[str]] = None) -> Namespace:
         parser = ArgumentParser()
@@ -19,18 +24,8 @@ class pFedFDAServer(FedAvgServer):
         parser.add_argument("--num_cv_folds", type=int, default=2)
         return parser.parse_args(arg_list)
 
-    def __init__(
-        self,
-        args: DictConfig,
-        algorithm_name: str = "pFedFDA",
-        unique_model=False,
-        use_fedavg_client_cls=False,
-        return_diff=False,
-    ):
-        super().__init__(
-            args, algorithm_name, unique_model, use_fedavg_client_cls, return_diff
-        )
-        self.init_trainer(pFedFDAClient)
+    def __init__(self, args: DictConfig):
+        super().__init__(args)
 
         self.global_means = torch.rand(
             [NUM_CLASSES[self.args.dataset.name], self.model.classifier.in_features]

--- a/src/server/pfedla.py
+++ b/src/server/pfedla.py
@@ -11,6 +11,10 @@ from src.server.fedavg import FedAvgServer
 
 
 class pFedLAServer(FedAvgServer):
+    algorithm_name: str = "pFedLA"
+    all_model_params_personalized = True
+    return_diff = True
+
     @staticmethod
     def get_hyperparams(args_list=None) -> Namespace:
         parser = ArgumentParser()
@@ -21,20 +25,11 @@ class pFedLAServer(FedAvgServer):
         parser.add_argument("--hidden_dim", type=int, default=100)
         return parser.parse_args(args_list)
 
-    def __init__(
-        self,
-        args: DictConfig,
-        algorithm_name: str = None,
-        unique_model=True,
-        use_fedavg_client_cls=True,
-        return_diff=True,
-    ):
+    def __init__(self, args: DictConfig):
         if args.mode == "parallel":
             raise NotImplementedError("pFedHN does not support paralell mode.")
-        algo = "pFedLA" if args.pfedla.k == 0 else "HeurpFedLA"
-        super().__init__(
-            args, algorithm_name, unique_model, use_fedavg_client_cls, return_diff
-        )
+        self.algorithm_name = "pFedLA" if args.pfedla.k == 0 else "HeurpFedLA"
+        super().__init__(args)
         self.hypernet = HyperNetwork(
             embedding_dim=self.args.pfedla.embedding_dim,
             layer_num=len(self.public_model_param_names),

--- a/src/server/pfedme.py
+++ b/src/server/pfedme.py
@@ -10,6 +10,11 @@ from src.server.fedavg import FedAvgServer
 
 
 class pFedMeServer(FedAvgServer):
+    algorithm_name: str = "pFedMe"
+    all_model_params_personalized = False  # `True` indicates that clients have their own fullset of personalized model parameters.
+    return_diff = False  # `True` indicates that clients return `diff = W_global - W_local` as parameter update; `False` for `W_local` only.
+    client_cls = pFedMeClient
+
     @staticmethod
     def get_hyperparams(args_list=None) -> Namespace:
         parser = ArgumentParser()
@@ -20,21 +25,11 @@ class pFedMeServer(FedAvgServer):
         parser.add_argument("--k", type=int, default=5)
         return parser.parse_args(args_list)
 
-    def __init__(
-        self,
-        args: DictConfig,
-        algorithm_name: str = "pFedMe",
-        unique_model=False,
-        use_fedavg_client_cls=False,
-        return_diff=False,
-    ):
-        super().__init__(
-            args, algorithm_name, unique_model, use_fedavg_client_cls, return_diff
-        )
+    def __init__(self, args: DictConfig):
+        super().__init__(args)
         self.clients_personalized_model_params = {
             i: deepcopy(self.model.state_dict()) for i in self.train_clients
         }
-        self.init_trainer(pFedMeClient)
 
     def package(self, client_id: int):
         server_package = super().package(client_id)

--- a/src/server/scaffold.py
+++ b/src/server/scaffold.py
@@ -10,28 +10,23 @@ from src.server.fedavg import FedAvgServer
 
 
 class SCAFFOLDServer(FedAvgServer):
+    algorithm_name: str = "SCAFFOLD"
+    all_model_params_personalized = False  # `True` indicates that clients have their own fullset of personalized model parameters.
+    return_diff = True  # `True` indicates that clients return `diff = W_global - W_local` as parameter update; `False` for `W_local` only.
+    client_cls = SCAFFOLDClient
+
     @staticmethod
     def get_hyperparams(args_list=None) -> Namespace:
         parser = ArgumentParser()
         parser.add_argument("--global_lr", type=float, default=1.0)
         return parser.parse_args(args_list)
 
-    def __init__(
-        self,
-        args: DictConfig,
-        algorithm_name: str = "SCAFFOLD",
-        unique_model=False,
-        use_fedavg_client_cls=False,
-        return_diff=True,
-    ):
-        super().__init__(
-            args, algorithm_name, unique_model, use_fedavg_client_cls, return_diff
-        )
+    def __init__(self, args: DictConfig):
+        super().__init__(args)
         self.c_global = [
             torch.zeros_like(param) for param in self.public_model_params.values()
         ]
         self.c_local = [deepcopy(self.c_global) for _ in self.train_clients]
-        self.init_trainer(SCAFFOLDClient)
 
     def package(self, client_id: int):
         server_package = super().package(client_id)

--- a/src/utils/constants.py
+++ b/src/utils/constants.py
@@ -94,8 +94,6 @@ DEFAULTS = {
         "save_metrics": True,
         "delete_useless_run": True,
     },
-    "fedprox": {"mu": 0.01},
-    "pfedsim": {"warmup_round": 0.5},
 }
 
 

--- a/src/utils/functional.py
+++ b/src/utils/functional.py
@@ -218,42 +218,6 @@ def parse_args(
     return final_args
 
 
-class Logger:
-    def __init__(
-        self, stdout: Console, enable_log: bool, logfile_path: Union[Path, str]
-    ):
-        """This class is for solving the incompatibility between the progress
-        bar and log function in library `rich`.
-
-        Args:
-            stdout (Console): The `rich.console.Console` for printing info onto stdout.
-            enable_log (bool): Flag indicates whether log function is actived.
-            logfile_path (Union[Path, str]): The path of log file.
-        """
-        self.stdout = stdout
-        self.logfile_output_stream = None
-        self.enable_log = enable_log
-        if self.enable_log:
-            self.logfile_output_stream = open(logfile_path, "w")
-            self.logfile_logger = Console(
-                file=self.logfile_output_stream,
-                record=True,
-                log_path=False,
-                log_time=False,
-                soft_wrap=True,
-                tab_size=4,
-            )
-
-    def log(self, *args, **kwargs):
-        self.stdout.log(*args, **kwargs)
-        if self.enable_log:
-            self.logfile_logger.log(*args, **kwargs)
-
-    def close(self):
-        if self.logfile_output_stream:
-            self.logfile_output_stream.close()
-
-
 def initialize_data_loaders(
     dataset: Dataset,
     data_indices: List[Dict[str, List[int]]],

--- a/src/utils/logger.py
+++ b/src/utils/logger.py
@@ -1,0 +1,52 @@
+import warnings
+from pathlib import Path
+from typing import Union
+
+from rich.console import Console
+
+
+class Logger:
+    def __init__(
+        self, stdout: Console, enable_log: bool, logfile_path: Union[Path, str]
+    ):
+        """This class is for solving the incompatibility between the progress
+        bar and log function in library `rich`.
+
+        Args:
+            stdout (Console): The `rich.console.Console` for printing info onto stdout.
+            enable_log (bool): Flag indicates whether log function is actived.
+            logfile_path (Union[Path, str]): The path of log file.
+        """
+        self.stdout = stdout
+        self.logfile_output_stream = None
+        self.enable_log = enable_log
+        if self.enable_log:
+            self.logfile_output_stream = open(logfile_path, "w")
+            self.logfile_logger = Console(
+                file=self.logfile_output_stream,
+                record=True,
+                log_path=False,
+                log_time=False,
+                soft_wrap=True,
+                tab_size=4,
+            )
+
+    def log(self, *args, **kwargs):
+        self.stdout.log(*args, **kwargs)
+        if self.enable_log:
+            self.logfile_logger.log(*args, **kwargs)
+
+    def warn(self, *args, **kwargs):
+        """Wrapper of `warnings.warn` to print the warning message onto
+        `stdout` and log file (if enabled)."""
+        msg = ""
+        with warnings.catch_warnings(record=True) as w:
+            warnings.warn(*args, **kwargs)
+            msg = str(w[-1].message)
+        self.stdout.log(msg)
+        if self.enable_log:
+            self.logfile_logger.log(msg)
+
+    def close(self):
+        if self.logfile_output_stream:
+            self.logfile_output_stream.close()

--- a/src/utils/trainer.py
+++ b/src/utils/trainer.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict, deque
-from typing import Any, Callable
+from typing import Any, Callable, Optional
 
 import ray
 import ray.actor
@@ -143,7 +143,7 @@ class FLbenchTrainer:
         self,
         func_name: str,
         clients: list[int],
-        package_func: Callable[[int], dict[str, Any]] = None,
+        package_func: Optional[Callable[[int], dict[str, Any]]] = None,
     ):
         if package_func is None:
             package_func = getattr(self.server, "package")
@@ -158,7 +158,7 @@ class FLbenchTrainer:
         self,
         func_name: str,
         clients: list[int],
-        package_func: Callable[[int], dict[str, Any]] = None,
+        package_func: Optional[Callable[[int], dict[str, Any]]] = None,
     ):
         if package_func is None:
             package_func = getattr(self.server, "package")


### PR DESCRIPTION
refactor(framework): Extract Logger class to separate module
- Move Logger class from functional.py to a new logger.py module
- Add a new `warn()` method to the Logger class for handling warnings
- Update type hints in trainer.py to use Optional for package_func

refactor(framework): Extract Logger class to separate module
- Move Logger class from functional.py to a new logger.py module
- Add a new `warn()` method to the Logger class for handling warnings
- Update type hints in trainer.py to use Optional for package_func
- Improve code consistency and reduce boilerplate in server implementations

refactor(config): Update defaults.yaml with improved comments and terminology

chore(deps): bump scikit-learn from 1.5.2 to 1.6.1 in /.env (#156)